### PR TITLE
Command line toml specification and accept either batch CSV of HUCs or single HUC from TOML

### DIFF
--- a/facet.py
+++ b/facet.py
@@ -17,6 +17,7 @@ and stream slope from DEMs.
 
 ------------------------------------------------------------------------------
 """
+import argparse
 import time
 from pathlib import Path
 
@@ -30,19 +31,36 @@ from src.metrics import floodplain_metrics
 
 from src.postprocessing import spatial_qc as qc
 
+
 # Debug WBT compile issue only on WSL Ubuntu 20.0
 # whitebox.download_wbt(linux_musl=True, reset=True)
 
 if __name__ == "__main__":
-
-    config_toml = Path("src/config_test.toml")
-    fpaths_toml = Path("src/utils/filepaths.toml")
+    
+    # Command line argument parsing for easier command line implementation
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config_toml", help = "filepath to configuration toml file, relative to root FACET directory, i.e., src/config_test.toml")
+    parser.add_argument("--fpaths_toml", help = "filepath to filepaths toml file, relative to root FACET directory, i.e. src/filepaths.toml")
+    args = parser.parse_args()
+    
+    config_toml = Path(args.config_toml)
+    fpaths_toml = Path(args.fpaths_toml)
+    
+    # config_toml = Path("src/config_test.toml")
+    # fpaths_toml = Path("src/utils/filepaths.toml")
 
     # step 1
     Config = parse_toml.create_config(config_toml)
 
     # step 2
-    hucs = generate_processing_batch(Config.batch_csv)
+    if ( Config.hucs['batch_csv'] != "None" ) & ( Config.hucs['huc'] != "None" ):
+        raise ValueError(f'Both a CSV of HUCs and an individual HUC are specified in the .toml, choose one or the other')
+    elif ( Config.hucs['batch_csv'] == "None" ) & ( Config.hucs['huc'] == "None" ):
+        raise ValueError(f'Both a CSV of HUCs and an individual HUC are set to "None" in the .toml, one these needs to have a valid value')
+    elif ( Config.hucs['batch_csv'] != "None" ):
+        hucs = generate_processing_batch(Config.batch_csv)
+    elif ( Config.hucs['huc'] != "None" ):
+        hucs = [ Config.hucs['huc'] ] # create a list containing the single HUC code so that it is iterable and the below for-loop does not break
 
     for huc in hucs:
         # step 3

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,7 +1,6 @@
 [hucs]
-batch_csv = "c:/chesapeake_bay/sample_data/batch.csv"
-
-huc = "None"
+batch_csv = "c:/chesapeake_bay/sample_data/batch.csv" # Absolute filepath of a CSV containing a list of HUC codes to process, set to "None" if using a single HUC code
+huc = "None" # Single HUC code to use ("0401030204"), set to "None" is using a CSV of HUC codes
 
 [ancillary]
 data = "c:/chesapeake_bay/sample_data"
@@ -11,6 +10,7 @@ nhd_wbds = "https://gis-data.chesapeakebay.net/facet_misc_data/NHDPlus_HR_Waterb
 physiography = "https://gis-data.chesapeakebay.net/facet_misc_data/physiography_orig.parquet"
 census_roads = "https://gis-data.chesapeakebay.net/facet_misc_data/Census_roads_2023.parquet"
 census_rails = "https://gis-data.chesapeakebay.net/facet_misc_data/Census_rails_2023.parquet"
+cutlines = ""
 
 [debug]
 version = "test-01" # short description of version
@@ -20,12 +20,17 @@ epsg = "5070"
 cell_size = 1
 
 [preprocess]
-preprocess = true
-    
+preprocess_flag = true # A flag to determine whether preprocessing occurs (this variable is currently unused / not implemented)
+
+	[preprocess.burn_cutlines]
+	burn_cutlines_flag = true # Flag to determine whether cutlines are burned into the DEM for hydro-enforcement
+	
     [preprocess.burn_stream_at_roads]
+	burn_stream_at_roads_flag = false # Flag to determine whether rail/road crossings are breached at pre-defined streamlines for hydro-enforcement
     width = 100
 
     [preprocess.denoise]
+	denoise_flag = false # Flag to determine whether DEM denoising is desired (highly suggested for high-resolution DEMs that have not yet been denoised)
     filter_size = 11
     norm_diff = 10
     num_iter = 3

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,4 +1,7 @@
+[hucs]
 batch_csv = "c:/chesapeake_bay/sample_data/batch.csv"
+
+huc = "None"
 
 [ancillary]
 data = "c:/chesapeake_bay/sample_data"

--- a/src/preprocessing/preprocess.py
+++ b/src/preprocessing/preprocess.py
@@ -7,6 +7,7 @@ import fiona
 from osgeo import gdal
 from osgeo_utils.gdal_polygonize import gdal_polygonize
 import rasterio
+import rasterstats
 from shapely.geometry import Point
 import subprocess
 import numpy as np
@@ -14,8 +15,28 @@ from src.utils import utils
 import time
 
 def clip_flowlines(flowlines, mask, output, logger):
+    """
+    Clips the provided flowlines to the watershed polygon boundary in case they
+    extend beyond it which would create problems in subsequent steps
 
-    if not output.is_file():
+    Parameters
+    ----------
+    flowlines : str
+        String defining the filepath for the input flowlines *.shp file (typically NHD Plus HR flowlines).
+    mask : WindowsPath object of pathlib module
+        Path to watershed polygon (typically a *.shp file).
+    output : WindowsPath object of pathlib module
+        Path where clipped flowlines are written (typically a *.shp file).
+    logger : Logger object of logging module
+        Logger writes processing information to text file.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    if not output.is_file(): # only enter this step if the file does not already exist
         aoi_flowlines = utils.vector_to_geodataframe(flowlines)
         mask = utils.vector_to_geodataframe(mask)
         flowlines = aoi_flowlines.clip(mask)
@@ -34,19 +55,45 @@ def clip_flowlines(flowlines, mask, output, logger):
             logger.info("NHD Flowlines clipped")
 
 
-def merge_rails_and_roads(aoi_rails, aoi_roads, mask, output, logger):
+def merge_rails_and_roads(out_epsg, aoi_rails, aoi_roads, mask, output, logger):
+    """
+    Clips the roads and rails line vector files to the watershed mask, and then
+    merges the clipped line vectors to a single combined file which is written
+    to the data/version directory.
 
-    if not output.is_file():
+    Parameters
+    ----------
+    out_epsg : Integer
+        Integer specifying the European Petroleum Geospatial Group code defining
+        the output horizontal coordinate reference system
+    aoi_rails : String
+        String defining the filepath for the railroad lines vector file (typically a *.shp file).
+    aoi_roads : String
+        String defining the filepath for the road lines vector file (typically a *.shp file).
+    mask : WindowsPath object of pathlib module
+        Path to watershed polygon (typically a *.shp file).
+    output : WindowsPath object of pathlib module
+        Path to watershed polygon (typically a *.shp file).
+    logger : Logger object of logging module
+        Logger writes processing information to text file.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    if not output.is_file(): # if the merged roads/rails file already exists, do not proceed with this step
         roads = utils.vector_to_geodataframe(aoi_roads)
         rails = utils.vector_to_geodataframe(aoi_rails)
-        mask = utils.vector_to_geodataframe(mask)
+        mask = utils.vector_to_geodataframe(mask).to_crs( epsg = out_epsg )
 
-        roads_mask = roads.clip(mask)
-        rails_mask = rails.clip(mask)
+        roads_mask = roads.clip( mask.to_crs( roads.crs ) ).to_crs( epsg = out_epsg )
+        rails_mask = rails.clip( mask.to_crs( rails.crs ) ).to_crs( epsg = out_epsg )
 
         road_rail_crossings = gpd.GeoDataFrame(
-            pd.concat([roads_mask, rails_mask], ignore_index=True), 
-            crs=mask.crs
+            pd.concat( [ roads_mask, rails_mask ], ignore_index = True), 
+            crs = mask.crs
         )
         road_rail_crossings.to_file(output)
         logger.info("Roads and rails merged")
@@ -54,47 +101,139 @@ def merge_rails_and_roads(aoi_rails, aoi_roads, mask, output, logger):
         logger.info("Roads and rails layer already exists. Skipping step")
 
 
+def burn_cutlines(dem, output, cutlines, out_epsg, logger):
+    """
+    Burn the cutlines into the DEM
+
+    Parameters
+    ----------
+    dem : WindowsPath object of pathlib module
+        Path to the input DEM which will be cut.
+    output : WindowsPath object of pathlib module
+        Path to which the cut DEM will be written.
+    cutlines : String
+        Path to the cutlines vector file (typically a *.
+    out_epsg : Integer
+        DESCRIPTION.
+    logger : Logger object of logging module
+        Logger writes processing information to text file.
+
+    Returns
+    -------
+    None.
+
+    """
+    
+    # Read in the cutlines and attribute them with the minimum DEM elevation
+    cutlines_gdf = utils.vector_to_geodataframe(cutlines).to_crs( epsg = out_epsg )
+    cut_zmin = rasterstats.zonal_stats( cutlines, dem, stats = "min" )
+    cutlines_gdf['elevation'] = [i['min'] for i in cut_zmin]
+    cutline_zip = zip(cutlines_gdf.geometry.values, cutlines_gdf.elevation.values)
+    
+    # Burn the cutlines into the DEM and write out to a new file
+    with rasterio.open(dem, "r") as src:
+        band_num = 1
+        src_image = src.read(band_num, out_dtype = src.meta['dtype'])
+        dem_cut = rasterio.features.rasterize( cutline_zip, out = src_image,
+                                              transform = src.transform,
+                                              all_touched = True )
+        
+        # save tif
+        profile = src.profile
+        profile.update( dtype= src.meta['dtype'], count = 1, compress = "lzw" )
+
+        with rasterio.open( output, "w", **profile ) as dst:
+            dst.write( dem_cut, 1 )
+
+
 def hydro_condition_dem(Config, Paths, logger):
+    """
+    Hydro-condition the provided DEM by burning in cutlines, burning in road/rail
+    crossings near pre-defined streams, denoising the DEM by applying a feature-
+    preverving smoothing algorithm, and breaching any remaining depressions.
+
+    Parameters
+    ----------
+    Config : CreatConfig object of src.utils.parse_tomle module
+        Object containing dictionaries specifying processing parameters.
+    Paths : CreateFilepaths object of src.utils.parse_tomle module
+        Object containing filepaths for the outputs of the FACET workflow.
+    logger : Logger object of logging module
+        Logger writes processing information to text file.
+        
+    Returns
+    -------
+    None.
+
+    """
+    
+    # Setup whiteboxtool options
     wbt = whitebox.WhiteboxTools()
     wbt._WhiteboxTools__compress_rasters = "True"
     wbt.set_verbose_mode(False)
 
+    # Merge rail/road features into a single file for "burn_stream_at_roads" function
     merge_rails_and_roads(
+        int( Config.spatial_ref['epsg'] ),
         Config.ancillary['census_rails'],
         Config.ancillary['census_roads'],
         Paths.watershed,
         Paths.road_rail_crossings,
         logger,
     )
+    
+    # Burn cutlines into DEM
+    if ( not Paths.burn_cutlines.is_file() ) & ( Config.preprocess['burn_cutlines']['burn_cutlines_flag'] == True ):
+        start = time.time()
+        burn_cutlines( Paths.dem, Paths.burn_cutlines, Config.ancillary['cutlines'], int( Config.spatial_ref['epsg'] ), logger )
+        run_time = round((time.time() - start) / 60, 2)
+        logger.info(f"Cutlines burned. Run-time: {run_time} mins")
+    elif Config.preprocess['burn_cutlines']['burn_cutlines_flag'] == False:
+        logger.info("Cutlines not burned -- burn_cutlines_flag == False")
+    else:
+        logger.info("Cutlines burned -- already exist!")
 
-    if not Paths.burn_crossings.is_file():
+
+    # Burn rail/road crossings into DEM where they intersect the flowlines vector file
+    if ( not Paths.burn_crossings.is_file() ) & ( Config.preprocess['burn_stream_at_roads']['burn_stream_at_roads_flag'] == True ):
         start = time.time()
         wbt.burn_streams_at_roads(
             Paths.dem, 
             Paths.flowlines, 
             Paths.road_rail_crossings, 
             Paths.burn_crossings, 
-            width=Config.preprocess['burn_stream_at_roads']['width'], 
+            width = Config.preprocess['burn_stream_at_roads']['width'], 
         )
         run_time = round((time.time() - start) / 60, 2)
         logger.info(f"Streams near roads burned. Run-time: {run_time} mins")
+    elif  Config.preprocess['burn_stream_at_roads']['burn_stream_at_roads_flag'] == False:
+        logger.info("Streams near roads not burned -- burn_stream_at_roads_flag == False!")
     else:
         logger.info("Streams near roads burned -- already exist!")
 
-    if not Paths.denoise.is_file():
-        start = time.time()
-        wbt.feature_preserving_smoothing(
-            Paths.burn_crossings, 
-            Paths.denoise, 
-            filter=Config.preprocess['denoise']['filter_size'],
-            norm_diff=Config.preprocess['denoise']['norm_diff'],
-            num_iter=Config.preprocess['denoise']['num_iter'],
-        )
-        run_time = round((time.time() - start) / 60, 2)
-        logger.info(f"Feature preserving smoothing (denoising) performed. Run-time: {run_time} mins")
+    # Denoise the DEM, or change the Paths.denoise path if the denoise_flag == False
+    if Config.preprocess['denoise']['denoise_flag'] == True: # Only enter the denoise process if the denoise_flag is True
+        if not Paths.denoise.is_file():
+            start = time.time()
+            wbt.feature_preserving_smoothing(
+                Paths.burn_crossings, 
+                Paths.denoise, 
+                filter=Config.preprocess['denoise']['filter_size'],
+                norm_diff=Config.preprocess['denoise']['norm_diff'],
+                num_iter=Config.preprocess['denoise']['num_iter'],
+            )
+            run_time = round((time.time() - start) / 60, 2)
+            logger.info(f"Feature preserving smoothing (denoising) performed. Run-time: {run_time} mins")
+        else:
+            logger.info("Feature preserving smoothing (denoising) performed -- already exist!")
     else:
-        logger.info("Feature preserving smoothing (denoising) performed -- already exist!")
-
+        if Paths.burn_cutlines.is_file():
+            Paths.denoise = Paths.burn_cutlines
+            logger.info("Feature preserving smoothing (denoising) not performed -- flag = False, using the unsmoothed, cutline burned DEM for future steps!")
+        if Paths.burn_crossings.is_file():
+            Paths.denoise = Paths.burn_crossings
+            logger.info("Feature preserving smoothing (denoising) not performed -- flag = False, using the unsmoothed, rail/road crossings burned DEM for future steps!")
+     
     if not Paths.breach.is_file():
         start = time.time()
         wbt.breach_depressions_least_cost(
@@ -273,6 +412,31 @@ def run_command(cmd, logger):
 
 
 def run_preprocessing_steps(Config, Paths, logger):
+    """ 
+    Run the pre-processing steps:
+            1. clip flowlines to watershed polygon
+            2. hydro-condition the DEM
+                a.
+                b.
+                c.
+            3. create weight grid from streamlines
+            4.
+    
+
+    Parameters
+    ----------
+    Config : CreatConfig object of src.utils.parse_tomle module
+        Object containing dictionaries specifying processing parameters.
+    Paths : CreateFilepaths object of src.utils.parse_tomle module
+        Object containing filepaths for the outputs of the FACET workflow.
+    logger : Logger object of logging module
+        Logger writes processing information to text file.
+
+    Returns
+    -------
+    None.
+
+    """
     clip_flowlines(Config.ancillary['flowlines'], Paths.watershed, Paths.flowlines, logger)
     hydro_condition_dem(Config, Paths, logger)
     create_weight_grid_from_streamlines(Paths.flowlines, Paths.watershed, Paths.dem, Paths.initiation_pixels, logger)

--- a/src/utils/filepaths.toml
+++ b/src/utils/filepaths.toml
@@ -10,6 +10,7 @@ physiography = "physiography.shp"
 
 # [pre-process]
 road_rail_crossings = "rr_crossings.shp"
+burn_cutlines = "burn_cutlines.tif"
 burn_crossings = "burn_crossings.tif"
 denoise = "denoise.tif"
 breach = "breach.tif"
@@ -18,6 +19,7 @@ d8_fdir_point = "d8_fdir_point.tif"
 slope_grid_sd8  = "slope_grid_sd8.tif" #sd8
 area_grid_ad8 = "area_grid_ad8.tif" #ad8_no_wg
 area_grid_ad8_ip = "area_grid_ad8_ip.tif" #ad8_wg
+network_raster = "network.tif" #stream_raster
 network_order = "network_order.tif" #ord_g
 network_tree = "network_tree.txt" #tree
 network_coords = "network_coords.txt" #coord

--- a/src/utils/parse_toml.py
+++ b/src/utils/parse_toml.py
@@ -86,10 +86,10 @@ def create_config(config_toml):
 def create_filepaths(paths_toml, config, huc):
     paths = read_toml(paths_toml)
     Paths = CreateFilepaths(
-        folder=config.ancillary['data'],
-        huc=huc,
-        version=config.debug['version'],
-        paths=paths
+        folder = config.ancillary['data'],
+        huc = huc,
+        version = config.debug['version'],
+        paths = paths
     )
 
     return Paths


### PR DESCRIPTION
I'm new to pull requests to please let me know if I should be doing things differently! 

1. Updated facet.py to read config_toml and fpaths_toml from command line arguments, as opposed to needing to change the script each time. 

```
    # Command line argument parsing for easier command line implementation
    parser = argparse.ArgumentParser()
    parser.add_argument("--config_toml", help = "filepath to configuration toml file, relative to root FACET directory, i.e., src/config_test.toml")
    parser.add_argument("--fpaths_toml", help = "filepath to filepaths toml file, relative to root FACET directory, i.e. src/filepaths.toml")
    args = parser.parse_args()
    
    config_toml = Path(args.config_toml)
    fpaths_toml = Path(args.fpaths_toml)
    
    # config_toml = Path("src/config_test.toml")
    # fpaths_toml = Path("src/utils/filepaths.toml")
```

Example function call `python facet.py --config_toml "src\config_0401030204_time1.toml" --fpaths_toml "src\utils\filepaths.toml"`
 

2. Updated facet.py to read either a single HUC code or a batch of HUC codes from the configuration file, rather than assuming a batch CSV is being provided. Included some error catching in case both or neither are provided..

```
    # step 2
    if ( Config.hucs['batch_csv'] != "None" ) & ( Config.hucs['huc'] != "None" ):
        raise ValueError(f'Both a CSV of HUCs and an individual HUC are specified in the .toml, choose one or the other')
    elif ( Config.hucs['batch_csv'] == "None" ) & ( Config.hucs['huc'] == "None" ):
        raise ValueError(f'Both a CSV of HUCs and an individual HUC are set to "None" in the .toml, one these needs to have a valid value')
    elif ( Config.hucs['batch_csv'] != "None" ):
        hucs = generate_processing_batch(Config.batch_csv)
    elif ( Config.hucs['huc'] != "None" ):
        hucs = [ Config.hucs['huc'] ] # create a list containing the single HUC code so that it is iterable and the below for-loop does not break
```

Updated the config.toml file to reflect the updated structure. I think there are probably some additional error-catching and argument formatting improvements that could be made relating to these changes.

```
[hucs]
batch_csv = "c:/chesapeake_bay/sample_data/batch.csv"
huc = "None"
```

3. Added a `burn_cutlines` functionality to `preprocess.py` similar to part of the [`ManualCutterDamBuilderP5.py`](https://uwmadison.app.box.com/s/mjypbubaw6ioc4h9jviguykcysewp0kp/file/1635717860665) functionality available through the [ACPF ArcPy toolbox](https://acpf4watersheds.org/). This functionality takes a vector file of cutlines, identifies the minimum elevation value along each cutline, and then burns that minimum elevation back into the DEM. `config.toml` was updated to include flags and data paths for this functionality. 

```
    # Read in the cutlines and attribute them with the minimum DEM elevation
    cutlines_gdf = utils.vector_to_geodataframe(cutlines).to_crs( epsg = out_epsg )
    cut_zmin = rasterstats.zonal_stats( cutlines, dem, stats = "min" )
    cutlines_gdf['elevation'] = [i['min'] for i in cut_zmin]
    cutline_zip = zip(cutlines_gdf.geometry.values, cutlines_gdf.elevation.values)
    
    # Burn the cutlines into the DEM and write out to a new file
    with rasterio.open(dem, "r") as src:
        band_num = 1
        src_image = src.read(band_num, out_dtype = src.meta['dtype'])
        dem_cut = rasterio.features.rasterize( cutline_zip, out = src_image,
                                              transform = src.transform,
                                              all_touched = True )
        
        # save tif
        profile = src.profile
        profile.update( dtype= src.meta['dtype'], count = 1, compress = "lzw" )

        with rasterio.open( output, "w", **profile ) as dst:
            dst.write( dem_cut, 1 )
```

4. Added functionality to skip the DEM denoising by adding a flag variable in `config.toml` and overwriting the denoise path if that flag is False. 

```
# Denoise the DEM, or change the Paths.denoise path if the denoise_flag == False
    if Config.preprocess['denoise']['denoise_flag'] == True: # Only enter the denoise process if the denoise_flag is True
        if not Paths.denoise.is_file():
            start = time.time()
            wbt.feature_preserving_smoothing(
                Paths.burn_crossings, 
                Paths.denoise, 
                filter=Config.preprocess['denoise']['filter_size'],
                norm_diff=Config.preprocess['denoise']['norm_diff'],
                num_iter=Config.preprocess['denoise']['num_iter'],
            )
            run_time = round((time.time() - start) / 60, 2)
            logger.info(f"Feature preserving smoothing (denoising) performed. Run-time: {run_time} mins")
        else:
            logger.info("Feature preserving smoothing (denoising) performed -- already exist!")
    else:
        if Paths.burn_cutlines.is_file():
            Paths.denoise = Paths.burn_cutlines
            logger.info("Feature preserving smoothing (denoising) not performed -- flag = False, using the unsmoothed, cutline burned DEM for future steps!")
        if Paths.burn_crossings.is_file():
            Paths.denoise = Paths.burn_crossings
            logger.info("Feature preserving smoothing (denoising) not performed -- flag = False, using the unsmoothed, rail/road crossings burned DEM for future steps!")
```
